### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,7 @@ include LICENSE.txt
 # If using Python 2.6 or less, then have to include package data, even though
 # it's already declared in setup.py
 # include sample/*.dat
+
+
+include requirements.txt
+include README.md


### PR DESCRIPTION
add missing files:

```
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.51, 0.55, 0.47
 * Package:    dev-python/aiohwenergy-0.7.0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   github@ducosebel.nl
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking aiohwenergy-0.7.0.tar.gz to /var/tmp/portage/dev-python/aiohwenergy-0.7.0/work
>>> Source unpacked in /var/tmp/portage/dev-python/aiohwenergy-0.7.0/work
>>> Preparing source in /var/tmp/portage/dev-python/aiohwenergy-0.7.0/work/aiohwenergy-0.7.0 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/aiohwenergy-0.7.0/work/aiohwenergy-0.7.0 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/aiohwenergy-0.7.0/work/aiohwenergy-0.7.0 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
Traceback (most recent call last):
  File "/var/tmp/portage/dev-python/aiohwenergy-0.7.0/work/aiohwenergy-0.7.0/setup.py", line 25, in <module>
    install_requires=list(val.strip() for val in open("requirements.txt")),
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
 * ERROR: dev-python/aiohwenergy-0.7.0::HomeAssistantRepository failed (compile phase):
 *   (no error message)
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_compile
 *   environment, line 2928:  Called distutils-r1_src_compile
 *   environment, line 1253:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_compile'
 *   environment, line  488:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 2606:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 2147:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 2145:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line  780:  Called distutils-r1_run_phase 'distutils-r1_python_compile'
 *   environment, line 1244:  Called distutils-r1_python_compile
 *   environment, line 1027:  Called esetup.py 'build' '-j' '6'
 *   environment, line 1686:  Called die
 * The specific snippet of code:
 *       "${@}" || die -n;

```