### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description="Python module to talk to HomeWizard Energy Devices.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(exclude=["contrib", "docs", "tests"]),
+    packages=find_packages(exclude=["contrib", "docs", "test"]),
     zip_safe=True,
     install_requires=list(val.strip() for val in open("requirements.txt")),
     classifiers=[


### PR DESCRIPTION
fix a typo in find_packages exclusion, otherwise it would install a package called "test" at top level, only "tests" is excluded (which does not exist).